### PR TITLE
Update stylelint to use stylelint-order

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -29,7 +29,7 @@
     "declaration-colon-newline-after": "always-multi-line",
     "declaration-colon-space-after": "always-single-line",
     "declaration-colon-space-before": "never",
-    "declaration-block-no-duplicate-properties": [true, "ignore": ["consecutive-duplicates-with-different-values"]],
+    "declaration-block-no-duplicate-properties": [true, {"ignore": ["consecutive-duplicates-with-different-values"]}],
     "declaration-block-no-shorthand-property-overrides": true,
     "declaration-block-semicolon-newline-after": "always-multi-line",
     "declaration-block-semicolon-space-after": "always-single-line",

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,4 +1,7 @@
 {
+  plugins: [
+    "stylelint-order"
+  ],
   rules: {
     at-rule-no-vendor-prefix: true,
     at-rule-name-case: "lower",
@@ -27,93 +30,12 @@
     declaration-colon-space-after: "always-single-line",
     declaration-colon-space-before: "never",
     declaration-block-no-duplicate-properties: [true, ignore: "consecutive-duplicates-with-different-values"],
-    declaration-block-no-ignored-properties: true,
     declaration-block-no-shorthand-property-overrides: true,
     declaration-block-semicolon-newline-after: "always-multi-line",
     declaration-block-semicolon-space-after: "always-single-line",
     declaration-block-semicolon-space-before: "never",
     declaration-block-single-line-max-declarations: 1,
     declaration-block-trailing-semicolon: "always",
-
-    declaration-block-properties-order: [
-      [
-        {
-          order: "strict",
-          properties: [
-            content
-          ]
-        }, {
-          order: "flexible",
-          properties: [
-            "background",
-            "color",
-            "fill",
-            "filter",
-            "font",
-            "letter",
-            "line-height",
-            "text",
-            "white-space",
-            "word"
-          ]
-        }, {
-          order: "flexible",
-          properties: [
-            "border",
-            "box-sizing",
-            "display",
-            "height",
-            "margin",
-            "max-height",
-            "max-width",
-            "min-height",
-            "min-width",
-            "outline",
-            "overflow",
-            "padding",
-            "vertical-align",
-            "visibility",
-            "width"
-          ]
-        }, {
-          order: "flexible",
-          properties: [
-            "align",
-            "flex",
-            "justify-content"
-          ]
-        }, {
-          order: "flexible",
-          properties: [
-            "bottom",
-            "float",
-            "left",
-            "position",
-            "right",
-            "top",
-            "z-index"
-          ]
-        }, {
-          order: "flexible",
-          properties: [
-            "animation",
-            "box-shadow",
-            "opacity",
-            "transition",
-            "transform"
-          ]
-        }, {
-          order: "flexible",
-          properties: [
-            "appearance",
-            "list-style",
-            "table-style",
-            "cursor"
-          ]
-        }
-      ],
-      { unspecified: "bottom" }
-    ],
 
     function-calc-no-unspaced-operator: true,
     function-comma-newline-after: "always-multi-line",
@@ -132,11 +54,10 @@
 
     max-empty-lines: 2,
     max-line-length: [ 120, {ignore: "non-comments"} ],
-    max-nesting-depth: 4,
+    max-nesting-depth: 6,
 
     media-feature-colon-space-after: "always",
     media-feature-colon-space-before: "never",
-    media-feature-no-missing-punctuation: true,
     media-feature-parentheses-space-inside: "never",
     media-feature-range-operator-space-after: "always",
     media-feature-range-operator-space-before: "always",
@@ -154,13 +75,117 @@
     number-max-precision: 3,
     number-no-trailing-zeros: true,
 
+    order/properties-order: [
+      {
+        order: "strict",
+        emptyLineBefore: "always",
+        properties: [
+          "content"
+        ]
+      }, {
+        order: "flexible",
+        emptyLineBefore: "always",
+        properties: [
+          "background",
+          "background-color",
+          "color",
+          "fill",
+          "filter",
+          "font",
+          "font-family",
+          "font-size",
+          "font-style",
+          "font-weight",
+          "letter",
+          "letter-spacing",
+          "line-height",
+          "text",
+          "text-align",
+          "text-decoration",
+          "text-transform",
+          "white-space",
+          "word"
+        ]
+      }, {
+        order: "flexible",
+        emptyLineBefore: "always",
+        properties: [
+          "border",
+          "border-top",
+          "border-left",
+          "border-bottom",
+          "border-right",
+          "border-radius",
+          "box-sizing",
+          "display",
+          "height",
+          "margin",
+          "margin-top",
+          "margin-left",
+          "margin-bottom",
+          "margin-right",
+          "max-height",
+          "max-width",
+          "min-height",
+          "min-width",
+          "outline",
+          "overflow",
+          "padding",
+          "padding-top",
+          "padding-left",
+          "padding-bottom",
+          "padding-right",
+          "vertical-align",
+          "visibility",
+          "width"
+        ]
+      }, {
+        order: "flexible",
+        properties: [
+          "align-items",
+          "align-self",
+          "flex",
+          "flex-direction",
+          "flex-shrink",
+          "flex-grow",
+          "justify-content"
+        ]
+      }, {
+        order: "flexible",
+        emptyLineBefore: "always",
+        properties: [
+          "bottom",
+          "float",
+          "left",
+          "position",
+          "right",
+          "top",
+          "z-index"
+        ]
+      }, {
+        order: "flexible",
+        emptyLineBefore: "always",
+        properties: [
+          "animation",
+          "box-shadow",
+          "opacity",
+          "transition",
+          "transform"
+        ]
+      }, {
+        order: "flexible",
+        emptyLineBefore: "always",
+        properties: [
+          "appearance",
+          "list-style",
+          "table-style",
+          "cursor"
+        ]
+      }
+    ],
+
     property-case: "lower",
     property-no-unknown: [true, {checkPrefixed: true}],
-
-    root-no-standard-properties: true,
-
-    rule-nested-empty-line-before: ["always-multi-line", {except: ["first-nested"]}],
-    rule-non-nested-empty-line-before: "always-multi-line",
 
     selector-attribute-brackets-space-inside: "never",
     selector-attribute-quotes: "always",
@@ -169,9 +194,8 @@
     selector-list-comma-newline-after: "always",
     selector-list-comma-space-before: "never",
     selector-max-empty-lines: 0,
-    selector-max-compound-selectors: 3,
+    selector-max-compound-selectors: 6,
     selector-max-specificity: "1,3,0",
-    selector-no-empty: true,
     selector-pseudo-class-case: "lower",
     selector-pseudo-class-no-unknown: true,
     selector-pseudo-class-parentheses-space-inside: "never",

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,91 +1,91 @@
 {
-  plugins: [
+  "plugins": [
     "stylelint-order"
   ],
-  rules: {
-    at-rule-no-vendor-prefix: true,
-    at-rule-name-case: "lower",
-    at-rule-name-space-after: "always",
-    at-rule-semicolon-newline-after: "always",
+  "rules": {
+    "at-rule-no-vendor-prefix": true,
+    "at-rule-name-case": "lower",
+    "at-rule-name-space-after": "always",
+    "at-rule-semicolon-newline-after": "always",
 
-    block-closing-brace-empty-line-before: "never",
-    block-closing-brace-newline-after: "always",
-    block-closing-brace-newline-before: "always-multi-line",
-    block-no-empty: true,
-    block-opening-brace-newline-after: "always-multi-line",
-    block-opening-brace-space-after: "always-single-line",
-    block-opening-brace-space-before: "always",
+    "block-closing-brace-empty-line-before": "never",
+    "block-closing-brace-newline-after": "always",
+    "block-closing-brace-newline-before": "always-multi-line",
+    "block-no-empty": true,
+    "block-opening-brace-newline-after": "always-multi-line",
+    "block-opening-brace-space-after": "always-single-line",
+    "block-opening-brace-space-before": "always",
 
-    color-hex-case: "lower",
-    color-hex-length: "short",
-    color-no-invalid-hex: true,
+    "color-hex-case": "lower",
+    "color-hex-length": "short",
+    "color-no-invalid-hex": true,
 
-    comment-empty-line-before: "always",
-    comment-no-empty: true,
-    comment-whitespace-inside: "always",
+    "comment-empty-line-before": "always",
+    "comment-no-empty": true,
+    "comment-whitespace-inside": "always",
 
-    declaration-bang-space-after: "never",
-    declaration-bang-space-before: "always",
-    declaration-colon-newline-after: "always-multi-line",
-    declaration-colon-space-after: "always-single-line",
-    declaration-colon-space-before: "never",
-    declaration-block-no-duplicate-properties: [true, ignore: "consecutive-duplicates-with-different-values"],
-    declaration-block-no-shorthand-property-overrides: true,
-    declaration-block-semicolon-newline-after: "always-multi-line",
-    declaration-block-semicolon-space-after: "always-single-line",
-    declaration-block-semicolon-space-before: "never",
-    declaration-block-single-line-max-declarations: 1,
-    declaration-block-trailing-semicolon: "always",
+    "declaration-bang-space-after": "never",
+    "declaration-bang-space-before": "always",
+    "declaration-colon-newline-after": "always-multi-line",
+    "declaration-colon-space-after": "always-single-line",
+    "declaration-colon-space-before": "never",
+    "declaration-block-no-duplicate-properties": [true, "ignore": ["consecutive-duplicates-with-different-values"]],
+    "declaration-block-no-shorthand-property-overrides": true,
+    "declaration-block-semicolon-newline-after": "always-multi-line",
+    "declaration-block-semicolon-space-after": "always-single-line",
+    "declaration-block-semicolon-space-before": "never",
+    "declaration-block-single-line-max-declarations": 1,
+    "declaration-block-trailing-semicolon": "always",
 
-    function-calc-no-unspaced-operator: true,
-    function-comma-newline-after: "always-multi-line",
-    function-comma-newline-before: "never-multi-line",
-    function-comma-space-after: "always-single-line",
-    function-comma-space-before: "never",
-    function-max-empty-lines: 0,
-    function-parentheses-newline-inside: "always-multi-line",
-    function-parentheses-space-inside: "never-single-line",
-    function-url-quotes: "always",
-    function-whitespace-after: "always",
+    "function-calc-no-unspaced-operator": true,
+    "function-comma-newline-after": "always-multi-line",
+    "function-comma-newline-before": "never-multi-line",
+    "function-comma-space-after": "always-single-line",
+    "function-comma-space-before": "never",
+    "function-max-empty-lines": 0,
+    "function-parentheses-newline-inside": "always-multi-line",
+    "function-parentheses-space-inside": "never-single-line",
+    "function-url-quotes": "always",
+    "function-whitespace-after": "always",
 
-    indentation: 4,
+    "indentation": 4,
 
-    length-zero-no-unit: true,
+    "length-zero-no-unit": true,
 
-    max-empty-lines: 2,
-    max-line-length: [ 120, {ignore: "non-comments"} ],
-    max-nesting-depth: 6,
+    "max-empty-lines": 2,
+    "max-line-length": [ 120, {"ignore": "non-comments"} ],
+    "max-nesting-depth": 6,
 
-    media-feature-colon-space-after: "always",
-    media-feature-colon-space-before: "never",
-    media-feature-parentheses-space-inside: "never",
-    media-feature-range-operator-space-after: "always",
-    media-feature-range-operator-space-before: "always",
+    "media-feature-colon-space-after": "always",
+    "media-feature-colon-space-before": "never",
+    "media-feature-parentheses-space-inside": "never",
+    "media-feature-range-operator-space-after": "always",
+    "media-feature-range-operator-space-before": "always",
 
-    media-query-list-comma-newline-after: "always-multi-line",
-    media-query-list-comma-space-after: "always-single-line",
-    media-query-list-comma-space-before: "never",
+    "media-query-list-comma-newline-after": "always-multi-line",
+    "media-query-list-comma-space-after": "always-single-line",
+    "media-query-list-comma-space-before": "never",
 
-    no-empty-source: true,
-    no-eol-whitespace: true,
-    no-extra-semicolons: true,
-    no-missing-end-of-source-newline: true,
+    "no-empty-source": true,
+    "no-eol-whitespace": true,
+    "no-extra-semicolons": true,
+    "no-missing-end-of-source-newline": true,
 
-    number-leading-zero: "never",
-    number-max-precision: 3,
-    number-no-trailing-zeros: true,
+    "number-leading-zero": "never",
+    "number-max-precision": 3,
+    "number-no-trailing-zeros": true,
 
-    order/properties-order: [
+    "order/properties-order": [
       {
-        order: "strict",
-        emptyLineBefore: "always",
-        properties: [
+        "order": "strict",
+        "emptyLineBefore": "always",
+        "properties": [
           "content"
         ]
       }, {
-        order: "flexible",
-        emptyLineBefore: "always",
-        properties: [
+        "order": "flexible",
+        "emptyLineBefore": "always",
+        "properties": [
           "background",
           "background-color",
           "color",
@@ -107,9 +107,9 @@
           "word"
         ]
       }, {
-        order: "flexible",
-        emptyLineBefore: "always",
-        properties: [
+        "order": "flexible",
+        "emptyLineBefore": "always",
+        "properties": [
           "border",
           "border-top",
           "border-left",
@@ -140,8 +140,8 @@
           "width"
         ]
       }, {
-        order: "flexible",
-        properties: [
+        "order": "flexible",
+        "properties": [
           "align-items",
           "align-self",
           "flex",
@@ -151,9 +151,9 @@
           "justify-content"
         ]
       }, {
-        order: "flexible",
-        emptyLineBefore: "always",
-        properties: [
+        "order": "flexible",
+        "emptyLineBefore": "always",
+        "properties": [
           "bottom",
           "float",
           "left",
@@ -163,9 +163,9 @@
           "z-index"
         ]
       }, {
-        order: "flexible",
-        emptyLineBefore: "always",
-        properties: [
+        "order": "flexible",
+        "emptyLineBefore": "always",
+        "properties": [
           "animation",
           "box-shadow",
           "opacity",
@@ -173,9 +173,9 @@
           "transform"
         ]
       }, {
-        order: "flexible",
-        emptyLineBefore: "always",
-        properties: [
+        "order": "flexible",
+        "emptyLineBefore": "always",
+        "properties": [
           "appearance",
           "list-style",
           "table-style",
@@ -184,38 +184,38 @@
       }
     ],
 
-    property-case: "lower",
-    property-no-unknown: [true, {checkPrefixed: true}],
+    "property-case": "lower",
+    "property-no-unknown": [true, {"checkPrefixed": true}],
 
-    selector-attribute-brackets-space-inside: "never",
-    selector-attribute-quotes: "always",
-    selector-combinator-space-after: "always",
-    selector-combinator-space-before: "always",
-    selector-list-comma-newline-after: "always",
-    selector-list-comma-space-before: "never",
-    selector-max-empty-lines: 0,
-    selector-max-compound-selectors: 6,
-    selector-max-specificity: "1,3,0",
-    selector-pseudo-class-case: "lower",
-    selector-pseudo-class-no-unknown: true,
-    selector-pseudo-class-parentheses-space-inside: "never",
-    selector-pseudo-element-case: "lower",
-    selector-pseudo-element-colon-notation: "double",
-    selector-pseudo-element-no-unknown: true,
-    selector-type-case: "lower",
-    selector-type-no-unknown: true,
+    "selector-attribute-brackets-space-inside": "never",
+    "selector-attribute-quotes": "always",
+    "selector-combinator-space-after": "always",
+    "selector-combinator-space-before": "always",
+    "selector-list-comma-newline-after": "always",
+    "selector-list-comma-space-before": "never",
+    "selector-max-empty-lines": 0,
+    "selector-max-compound-selectors": 6,
+    "selector-max-specificity": "1,3,0",
+    "selector-pseudo-class-case": "lower",
+    "selector-pseudo-class-no-unknown": true,
+    "selector-pseudo-class-parentheses-space-inside": "never",
+    "selector-pseudo-element-case": "lower",
+    "selector-pseudo-element-colon-notation": "double",
+    "selector-pseudo-element-no-unknown": true,
+    "selector-type-case": "lower",
+    "selector-type-no-unknown": true,
 
-    shorthand-property-no-redundant-values: true,
+    "shorthand-property-no-redundant-values": true,
 
-    string-no-newline: true,
-    string-quotes: "double",
+    "string-no-newline": true,
+    "string-quotes": "double",
 
-    unit-case: "lower",
-    unit-no-unknown: true,
+    "unit-case": "lower",
+    "unit-no-unknown": true,
 
-    value-list-comma-newline-after: "always-multi-line",
-    value-list-comma-space-after: "always-single-line",
-    value-list-comma-space-before: "never",
-    value-list-max-empty-lines: 0
+    "value-list-comma-newline-after": "always-multi-line",
+    "value-list-comma-space-after": "always-single-line",
+    "value-list-comma-space-before": "never",
+    "value-list-max-empty-lines": 0
   }
 }


### PR DESCRIPTION
Now using `stylelint-order` instead of the deprecated `declaration-block-properties-order`.

Also, removed deprecated rules : 
- declaration-block-no-ignored-properties
- media-feature-no-missing-punctuation
- root-no-standard-properties
- rule-nested-empty-line-before
- rule-non-nested-empty-line-before
- selector-max-compound-selectors
- selector-no-empty